### PR TITLE
polish chinese translation of question about anarchism

### DIFF
--- a/langs/zh/questions.js
+++ b/langs/zh/questions.js
@@ -1440,7 +1440,7 @@ var questions = [
         valuesNo: []
     },
     {
-        question: '联邦应该被废除。',
+        question: '国家应该被废除。',
         answer: 0,
         valuesYes: [{
                 axis: 'anar',


### PR DESCRIPTION
The word "state" should be translated into "国家" not "联邦". In the sentence "The State should be abolished.", the word "State" refers to "Nation/国家", not "Federation/联邦" in chinese.