### PR TITLE
Update fr.json "regulation_retirement_age" entry translation

### DIFF
--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -43,7 +43,7 @@
     "capitalism_private_industry_sectors": "Il est acceptable que certains secteurs de l'industrie soient privés.",
     "capitalism_private_banks": "Les banques doivent rester privées.",
     "regulation_income_tax_redistribution": "Il faut taxer les revenus et le capital pour redistribuer les richesses.",
-    "regulation_retirement_age": "Nous devrions partir à la retraite plus tard.",
+    "regulation_retirement_age": "Nous devrions partir à la retraite plus tôt.",
     "regulation_unjustified_dismissals": "Les licenciements doivent être interdits sauf dans des cas justifiés.",
     "regulation_wage_control": "Le niveau des salaires doit être contrôlé pour garantir qu’un travailleur puisse vivre de son travail.",
     "regulation_monopoly_prevention": "Il est nécessaire d’empêcher la création de monopoles privés.",


### PR DESCRIPTION
correct "earlier" translation into "plus tôt" instead of "plus tard" which means "later"

We should be retiring earlier -> Nous devrions partir à la retraite plus tôt.

